### PR TITLE
CI: Pre-commit moved to pre-commit.ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,10 +45,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
-      - name: Run pre-commit hooks
-        run: |
-          uv run pre-commit run --all-files
-
       - name: Run tests with coverage
         run: |
           uv run pytest --cov=src --cov-report=xml --cov-report=term


### PR DESCRIPTION
Use pre-commit.ci for running pre-commit hooks instead of doing it
locally in the GitHub Actions workflow. This reduces redundancy and leverages
the dedicated service for managing pre-commit hooks.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
